### PR TITLE
Fix get_transaction json parameter name

### DIFF
--- a/eospy/cleos.py
+++ b/eospy/cleos.py
@@ -105,8 +105,11 @@ class Cleos :
         return self.post('account_history.get_controlled_accounts', params=None, json={'controlling_account':acct_name})
 
     def get_transaction(self, trans_id) :
-        ''' '''
-        return self.post('history.get_transaction', params=None, json={'transaction_id':trans_id})
+        '''
+        POST /v1/history/get_transaction
+        {"id":"abcd1234"}
+        '''
+        return self.post('history.get_transaction', params=None, json={'id': trans_id})
 
     def get_table(self, code, scope, table, table_key, lower_bound='0', upper_bound='-1', limit=10) :
         '''


### PR DESCRIPTION
This PR fixes the json parameter for `/v1/history/get_transaction` from `transaction_id` to `id`.

```
ross@v1020-wn-66-183 ~> curl -X POST http://api.eosnewyork.io/v1/history/get_transaction -H "Content-Type: application/json" --data '{"transaction_id": "d01614d6b5ec3d5459a37fb5d0c408e410e1e6c3813b20baff98a0e57f14016a"}'
{"id":"0000000000000000000000000000000000000000000000000000000000000000","trx":null,...                           
ross@v1020-wn-66-183 ~> curl -X POST http://api.eosnewyork.io/v1/history/get_transaction -H "Content-Type: application/json" --data '{"id": "d01614d6b5ec3d5459a37fb5d0c408e410e1e6c3813b20baff98a0e57f14016a"}'
{"id":"d01614d6b5ec3d5459a37fb5d0c408e410e1e6c3813b20baff98a0e57f14016a","trx":{"receipt":{"status":"executed","cpu_usage_us":1062,"net_usage_words":18,"trx":...
```