### PR TITLE
Name of EOS shoud be changed to SYS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ https://www.atlassian.com/git/tutorials/install-git
 3. Install eospy
 ```
 # install from github
-# look [here](https://github.com/eosnewyork/eospy/releases) for the latest release.
 pip install git+https://github.com/eosnewyork/eospy.git@<release>
 # install from pip
 pip install libeospy
 ```
+look [here](https://github.com/eosnewyork/eospy/releases) for the latest release.
 
 ## API Endpoints
 For a more complete list of API endpoints check out:

--- a/examples/create_user.py
+++ b/examples/create_user.py
@@ -9,7 +9,7 @@ key = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
 # key = eospy.keys.EOSKey('5HuaTWKeGzZhqyzuzFAjjFjPnnnjdgcp562oBSS8Wv1qgDSkR2W')
 
 resp = ce.create_account('eosio', key, 'testtesttest', 'EOS5YMv2UBcuiExv1C8fZjjnE4evofRdBh5Nrt8TYz44G7KC5tZNq', 'EOS5YMv2UBcuiExv1C8fZjjnE4evofRdBh5Nrt8TYz44G7KC5tZNq',
-                         stake_net='1.0000 EOS', stake_cpu='1.0000 EOS', ramkb=8, permission='active', transfer=False, broadcast=True)
+                         stake_net='1.0000 SYS', stake_cpu='1.0000 SYS', ramkb=8, permission='active', transfer=False, broadcast=True)
 
 print('------------------------------------------------')
 print(resp)

--- a/examples/push_transaction.py
+++ b/examples/push_transaction.py
@@ -7,7 +7,7 @@ payload = [
             'args': {
                 "from": "eosio",  # sender
                 "to": "bob123451234",  # receiver
-                "quantity": '1.0000 EOS',  # In EOS
+                "quantity": '1.0000 SYS',  # In SYS
                 "memo": "EOS to the moon",
             },
             "account": "eosio.token",

--- a/examples/test.yaml
+++ b/examples/test.yaml
@@ -13,7 +13,7 @@ tests: # tests to run and whether they should fail or not
         parameters:
           from: bob123451234
           to: eosio
-          quantity: "100.0000 EOS"
+          quantity: "100.0000 SYS"
           memo: "test1"
         exception: no
   - name: test_transfer_fail
@@ -27,7 +27,7 @@ tests: # tests to run and whether they should fail or not
         parameters:
           from: bob123451234
           to: eosio
-          quantity: "100.0000 EOS"
+          quantity: "100.0000 SYS"
           memo: "test1"
         exception: yes
   - name: test_voting_producers


### PR DESCRIPTION
The tests have errors due to different asset name.
The system token's name is SYS since Dawn 4.1 update.
I thought it should be applied to the tests too.